### PR TITLE
add function decorator to fix broken functions that don't return 3

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -26,15 +26,15 @@ class TestThree(unittest.TestCase):
     def test_factorial(self):
         self.assertEqual(three.factorial(), 3 * 2 * 1)
 
-    
+
     def test_is_three(self):
         self.assertTrue(three.is_three(3), "Should be true.")
 
 
     def test_filter(self):
         test_items = [1, 3, None, True, "happy", 3]
-        self.assertEqual(three.filter(test_items), 
-                            list(filter(three.is_three, test_items)), 
+        self.assertEqual(three.filter(test_items),
+                            list(filter(three.is_three, test_items)),
                             "The two lists should be the same.")
 
 
@@ -43,11 +43,19 @@ class TestThree(unittest.TestCase):
         self.assertEqual(three.map(test_items),
                             list(map(lambda x: 3, test_items)),
                             "The two lists should be the same.")
-                            
+
 
     def test_reduce(self):
         test_items = [1, 3, None, True, "happy", 3]
         self.assertEqual(three.reduce(test_items), 3)
+
+    def test_force_three(self):
+
+        @three.force_three
+        def function_about_four():
+            return 4
+
+        self.assertEqual(function_about_four(), 3)
 
 
 if __name__ == "__main__":

--- a/three/three.py
+++ b/three/three.py
@@ -41,7 +41,7 @@ def map(items):
 
 
 def reduce(items):
-    return three()    
+    return three()
 
 
 # Currency
@@ -59,7 +59,7 @@ def rule_of():
     return 'Things that come in 3s are inherently more appealing.'
 
 
-# Novelty 
+# Novelty
 def musketeers():
     return ['Athos', 'Aramis', 'Porthos']
 
@@ -73,7 +73,7 @@ def wise_men():
 
 
 def little_pigs():
-    """Returns a list of the materials used in the story 'Three Little Pigs'""" 
+    """Returns a list of the materials used in the story 'Three Little Pigs'"""
     return ['Straw', 'Sticks', 'Bricks']
 
 
@@ -85,3 +85,8 @@ def leches():
 
 def peas():
     return 'As close as three peas in a pod'
+
+def force_three(func):
+    def inner(*args, **kwargs):
+        return 3
+    return inner


### PR DESCRIPTION
First: I love this repo, what a fun idea

This PR adds a function decorator to fix all those broken functions out there that do something other than return `3`.

```
from three import force_three
@force_three
def return_four():
    return 4
print(return_four())
```

This would print 3, as all correct functions should.

---

Sorry about all the whitespace noise in the diff, my editor didn't like all the whitespace at the end of lines and such and seems to have automatically removed it