### PR TITLE
add reboot function to reboot system in n*3 minutes

### DIFF
--- a/three/three.py
+++ b/three/three.py
@@ -234,3 +234,8 @@ def shutdown(n=1):
     #function to shutdown the system in a multiple of three minutes - how can you schedule your shutdown without three?
     if type(n) == int:
         subprocess.call(['shutdown', f'+{n*3}'])
+
+def reboot(n=1):
+    #function to reboot the system in a multiple of three minutes - again, how else would you do that?
+    if type(n) == int:
+        subprocess.call(['shutdown', '-r', f'+{n*3}'])


### PR DESCRIPTION
How else would you that? Using a multiple of three minutes is truly the only way to properly schedule a reboot of your system.